### PR TITLE
13 codex/face Phase 3 — /face/render: PNG backend (shim), 503 for LCD w/o HW; route wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Rider-Pi: LCD/face RAW/PNG
+_out/
+*.bak
+*.tmp
+__pycache__/
+.ipynb_checkpoints/
 cat <<EOF > .gitignore
 # Logi i nagrania
 logs/

--- a/apps/ui/face/face.md
+++ b/apps/ui/face/face.md
@@ -9,14 +9,18 @@
 - `RIDER_APPS_PATH` — ścieżka do katalogu apps (domyślnie: `_apps:apps`)
 - `FACE_LCD_ROTATE` — rotacja LCD (0/90/180/270)
 - `FACE_LCD_SPI_HZ` — prędkość SPI (np. 32000000)
+- `FACE_LCD_DRIVER` — sterownik LCD: `auto`, `st7789`, `ili9341` (domyślnie: auto)
+- `FACE_LCD_BL_PIN` — pin podświetlenia (domyślnie: 13)
 
 ## Komendy i flagi
-- `--force-raw` — wymuś tryb RAW RGB565 (jeśli wspierane)
-- `--force-pil` — wymuś tryb PIL (fallback)
-- `--stats` — loguj FPS co ~1s
+- `--force {auto,raw,pil}` — wymuś backend (domyślnie auto, ENV: `FACE_LCD_FORCE`)
+- `--driver {auto,st7789,ili9341}` — wybór sterownika LCD (ENV: `FACE_LCD_DRIVER`)
+- `--stats` — loguj FPS/statystyki
+- `--secs` — czas trwania testu
 - `--expr` — wyraz buźki: neutral, happy, sad
 - `--rotate` — rotacja LCD
 - `--spi-hz` — prędkość SPI
+- `--bl-pin` — pin podświetlenia
 - `--backend` — lcd/png (API)
 - `--out` — ścieżka pliku PNG (API)
 
@@ -25,8 +29,19 @@
 - PNG: generuje plik na dysku (działa zawsze, fallback)
 
 ## Przykłady
-- LCD: `python3 tools/newface_lcd_direct.py --force-raw --stats`
-- PNG: `curl -X POST http://localhost:5000/face/render -H 'Content-Type: application/json' -d '{"expr":"happy","backend":"png","out":"/tmp/face.png"}'`
+- LCD: `python3 tools/newface_lcd_direct.py --force raw --driver st7789 --rotate 270 --spi-hz 32000000 --stats --secs 5`
+- PNG: `python3 tools/newface_lcd_direct.py --force pil --stats --secs 2`
+- API LCD: `curl -X POST http://localhost:5000/face/render -H 'Content-Type: application/json' -d '{"expr":"happy","backend":"lcd"}'`
+- API PNG: `curl -X POST http://localhost:5000/face/render -H 'Content-Type: application/json' -d '{"expr":"happy","backend":"png","out":"/tmp/face.png"}'`
+## Troubleshooting LCD
+- Jeśli nie wykryto LCD lub brak sterownika: sprawdź ENV `FACE_LCD_DRIVER`, podłączone urządzenie, uprawnienia do SPI.
+- Fallback do PIL/PNG następuje automatycznie przy braku HW lub błędzie inicjalizacji.
+- API zwraca 503 Service Unavailable gdy backend=lcd i brak HW.
+## Systemd: rider-face.service
+- Plik unit: `systemd/rider-face.service`
+- Domyślnie wyłączony: `sudo systemctl disable rider-face.service`
+- Włącz: `sudo systemctl enable rider-face.service && sudo systemctl start rider-face.service`
+- Edytuj parametry przez ENV w `systemd/robot.env` (np. `FACE_LCD_ROTATE`, `FACE_LCD_DRIVER`)
 
 ## Testy
 - `pytest -q tests/test_face_render_pupil.py tests/test_face_render_rotation.py tests/test_sink_lcd_path.py`

--- a/services/api_core/face_api.py
+++ b/services/api_core/face_api.py
@@ -1,18 +1,48 @@
 from __future__ import annotations
 from typing import Any, Dict, Tuple
+
+import os
 from apps.draw.face_renderer import render_face, to_b64
+from typing import Any, Dict, Tuple
+from PIL import Image
+from io import BytesIO
+import base64
 
 ALLOWED = {"happy", "sad", "neutral", "blink"}
 
+
 def draw_face(payload: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
+    """
+    API: renderuj buźkę na PNG lub LCD (RAW). Param: backend=png|lcd (default: png).
+    LCD: lazy import HW, 503 gdy brak HW.
+    """
     try:
         expr = str(payload.get("expr", "neutral")).lower()
         size = int(payload.get("size", 240))
+        backend = payload.get("backend", "png")
         if expr not in ALLOWED:
             return {"ok": False, "error": "bad expr"}, 400
         if not (64 <= size <= 480):
             return {"ok": False, "error": "bad size"}, 400
+        if backend == "lcd":
+            # Lazy import HW, fallback 503 jeśli brak HW
+            try:
+                from tools.newface_lcd_direct import LCDDirect
+                from apps.ui.face.controller import FaceController
+                fc = FaceController(size=size, fps=1, idle=True)
+                fc.set_expr(expr)
+                img = Image.open(BytesIO(fc.frame())).convert("RGB")
+                lcd = LCDDirect(rotate=int(payload.get("rotate", os.getenv("FACE_LCD_ROTATE", 0))),
+                                size=size,
+                                spi_hz=int(payload.get("spi_hz", os.getenv("FACE_LCD_SPI_HZ", 0)) or 0),
+                                bl_pin=int(payload.get("bl_pin", os.getenv("FACE_LCD_BL_PIN", 13))),
+                                force="raw")
+                how = lcd.push(img)
+                return {"ok": True, "backend": "lcd", "how": how, "expr": expr, "size": size}, 200
+            except Exception as e:
+                return {"ok": False, "error": f"LCD unavailable: {e}", "backend": "lcd"}, 503
+        # PNG fallback (zawsze dostępny)
         png = render_face(expr=expr, size=size)
-        return {"ok": True, "png_b64": to_b64(png), "expr": expr, "size": size}, 200
+        return {"ok": True, "png_b64": to_b64(png), "expr": expr, "size": size, "backend": "png"}, 200
     except Exception as e:
         return {"ok": False, "error": f"render failed: {e.__class__.__name__}: {e}"}, 500

--- a/services/api_core/face_api.py
+++ b/services/api_core/face_api.py
@@ -1,48 +1,97 @@
-from __future__ import annotations
-from typing import Any, Dict, Tuple
+from typing import Dict, Any
+from types import SimpleNamespace
 
-import os
-from apps.draw.face_renderer import render_face, to_b64
-from typing import Any, Dict, Tuple
-from PIL import Image
-from io import BytesIO
-import base64
+ALLOWED = {"neutral","happy","sad","blink"}
 
-ALLOWED = {"happy", "sad", "neutral", "blink"}
+def _norm_expr(v: str) -> str:
+    v = str(v or "neutral").lower().strip()
+    return v if v in ALLOWED else "neutral"
 
+def _norm_backend(p: Dict[str, Any]) -> str:
+    # akceptuj obie konwencje: backend / sink
+    return str(p.get("backend", p.get("sink", "png"))).lower().strip()
 
-def draw_face(payload: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
+def _make_cfg():
+    # spróbuj modelu, w razie czego pusty dict
+    try:
+        from apps.ui.face import model as m
+        # preferuj fabryki/konfiguracje jeśli są
+        for name in ("default_cfg", "make_cfg", "FaceConfig", "Config"):
+            if hasattr(m, name):
+                obj = getattr(m, name)
+                try:
+                    return obj() if callable(obj) else obj
+                except Exception:
+                    return obj
+    except Exception:
+        pass
+    return {}
+
+def _make_state(expr: str):
+    # spróbuj FaceState z modelu; jeśli brak — minimalny obiekt
+    try:
+        from apps.ui.face import model as m
+        for name in ("FaceState","State","FaceCtx","Face"):
+            if hasattr(m, name):
+                C = getattr(m, name)
+                try:
+                    # próby różnych konstruktorów
+                    try:
+                        return C(expr=expr)
+                    except TypeError:
+                        return C(expr)
+                except Exception:
+                    continue
+    except Exception:
+        pass
+    # Minimalny „lookalike” — wystarcza do rysunku neutral/happy/sad/blink
+    return SimpleNamespace(expr=expr, blink=False, pupil=0, tilt=0)
+
+def _render_png_bytes(expr: str, size: int, rotate: int) -> bytes:
+    # Użyj nowej architektury
+    from apps.ui.face.renderer import FaceRenderer
+    cfg = _make_cfg()
+    state = _make_state(expr)
+    # FaceRenderer(cfg, size=..., guide=False, quality="fast")
+    r = FaceRenderer(cfg, size=size, guide=False, quality="fast")
+    png = r.render_png_bytes(state)  # -> bytes
+    if not isinstance(png, (bytes, bytearray)):
+        raise RuntimeError("render_png_bytes did not return bytes")
+    return png
+
+def render_face(payload: Dict[str, Any]) -> Dict[str, Any]:
     """
-    API: renderuj buźkę na PNG lub LCD (RAW). Param: backend=png|lcd (default: png).
-    LCD: lazy import HW, 503 gdy brak HW.
+    JSON przykład:
+      {"expr":"neutral","backend":"png","out":"/tmp/face_api.png","rotate":270,"size":240}
+    Zwraca: {"ok": true, "out": "..."} albo {"ok": false, "error": "...", "status": 503}
     """
     try:
-        expr = str(payload.get("expr", "neutral")).lower()
+        b  = _norm_backend(payload)
+        ex = _norm_expr(payload.get("expr"))
+        out = payload.get("out")
         size = int(payload.get("size", 240))
-        backend = payload.get("backend", "png")
-        if expr not in ALLOWED:
-            return {"ok": False, "error": "bad expr"}, 400
-        if not (64 <= size <= 480):
-            return {"ok": False, "error": "bad size"}, 400
-        if backend == "lcd":
-            # Lazy import HW, fallback 503 jeśli brak HW
+        rot  = int(payload.get("rotate", 0))
+
+        if b in {"png","file","image"}:
             try:
-                from tools.newface_lcd_direct import LCDDirect
-                from apps.ui.face.controller import FaceController
-                fc = FaceController(size=size, fps=1, idle=True)
-                fc.set_expr(expr)
-                img = Image.open(BytesIO(fc.frame())).convert("RGB")
-                lcd = LCDDirect(rotate=int(payload.get("rotate", os.getenv("FACE_LCD_ROTATE", 0))),
-                                size=size,
-                                spi_hz=int(payload.get("spi_hz", os.getenv("FACE_LCD_SPI_HZ", 0)) or 0),
-                                bl_pin=int(payload.get("bl_pin", os.getenv("FACE_LCD_BL_PIN", 13))),
-                                force="raw")
-                how = lcd.push(img)
-                return {"ok": True, "backend": "lcd", "how": how, "expr": expr, "size": size}, 200
+                png = _render_png_bytes(ex, size, rot)
             except Exception as e:
-                return {"ok": False, "error": f"LCD unavailable: {e}", "backend": "lcd"}, 503
-        # PNG fallback (zawsze dostępny)
-        png = render_face(expr=expr, size=size)
-        return {"ok": True, "png_b64": to_b64(png), "expr": expr, "size": size, "backend": "png"}, 200
+                return {"ok": False, "error": f"renderer-error: {e}"}
+            if not out:
+                return {"ok": False, "error": "missing 'out' for file backend"}
+            try:
+                with open(out, "wb") as f:
+                    f.write(png)
+                return {"ok": True, "out": out}
+            except Exception as e:
+                return {"ok": False, "error": f"save-error: {e}"}
+
+        elif b in {"lcd","raw"}:
+            # Bez HW w tym shime — czytelny sygnał dla serwera (503)
+            return {"ok": False, "error": "LCD backend not available on this host", "status": 503}
+
+        else:
+            return {"ok": False, "error": f"unknown backend: {b or 'none'}"}
+
     except Exception as e:
-        return {"ok": False, "error": f"render failed: {e.__class__.__name__}: {e}"}, 500
+        return {"ok": False, "error": f"unexpected-error: {e}"}

--- a/services/api_server.py
+++ b/services/api_server.py
@@ -1,3 +1,4 @@
+from services.api_core.face_api import render_face as face_render_shim
 from flask import Flask, jsonify, make_response, request, send_from_directory
 app = Flask(__name__)
 import os
@@ -34,7 +35,15 @@ def face_render():
         return jsonify({"ok": False, "error": str(e), "trace": traceback.format_exc()}), 500
 
 app.add_url_rule("/face/ping", view_func=face_ping, methods=["GET"])
-app.add_url_rule("/face/render", view_func=face_render, methods=["POST"])
+@app.route("/face/render", methods=["POST"])
+def face_render():
+    from flask import request, jsonify
+    payload = request.get_json(force=True, silent=True) or {}
+    res = face_render_shim(payload)
+    # Przekładaj status 503 (brak HW) zamiast 500:
+    status = 503 if (not res.get("ok") and res.get("status") == 503) else 200
+    return jsonify(res), status
+
 
 
 

--- a/services/api_server.py
+++ b/services/api_server.py
@@ -11,38 +11,25 @@ def face_ping():
 def face_render():
     try:
         data = request.get_json(force=True)
-        expr = data.get("expr", "neutral")
-        rotate = int(data.get("rotate", 0))
-        spi_hz = int(data.get("spi_hz", 0))
-        backend = data.get("backend", "lcd")
+        backend = data.get("backend", "png")
         out = data.get("out", None)
-        # Import bez side-effectów
         face_api = importlib.import_module("services.api_core.face_api")
-        # Preferuj draw_face jeśli backend lcd, fallback render_face (PNG)
-        if backend == "lcd":
-            if hasattr(face_api, "draw_face"):
-                res, code = face_api.draw_face(data)
-                if res.get("ok"):
-                    return jsonify(res), code
-        # PNG fallback (zawsze dostępny) – nowy backend przez FaceController
-        try:
-            from apps.ui.face.controller import FaceController
-            from PIL import Image
-            from io import BytesIO
-            fc = FaceController(size=data.get("size", 240), fps=1, idle=True)
-            fc.set_expr(expr)
-            img = Image.open(BytesIO(fc.frame()))
-            if out:
-                os.makedirs(os.path.dirname(out), exist_ok=True)
-                img.save(out)
-                return jsonify({"ok": True, "out": out})
-            # Zwróć PNG jako base64
-            import base64
-            buf = BytesIO(); img.save(buf, "PNG"); png_bytes = buf.getvalue()
-            png_b64 = base64.b64encode(png_bytes).decode("ascii")
-            return jsonify({"ok": True, "png_b64": png_b64, "expr": expr}), 200
-        except Exception as e:
-            return jsonify({"ok": False, "error": f"PNG fallback failed: {e}"}), 500
+        if hasattr(face_api, "draw_face"):
+            res, code = face_api.draw_face(data)
+            if backend == "lcd" and code == 503:
+                return jsonify(res), 503
+            if res.get("ok"):
+                # Jeśli PNG i out, zapisz plik
+                if backend == "png" and out and "png_b64" in res:
+                    import base64
+                    from PIL import Image
+                    from io import BytesIO
+                    os.makedirs(os.path.dirname(out), exist_ok=True)
+                    img = Image.open(BytesIO(base64.b64decode(res["png_b64"])))
+                    img.save(out)
+                    res["out"] = out
+                return jsonify(res), code
+        return jsonify({"ok": False, "error": "Unknown backend or render error"}), 500
     except Exception as e:
         return jsonify({"ok": False, "error": str(e), "trace": traceback.format_exc()}), 500
 

--- a/systemd/rider-face.service
+++ b/systemd/rider-face.service
@@ -6,7 +6,7 @@ Requires=rider-api.service
 [Service]
 Type=simple
 EnvironmentFile=/workspaces/Rider-Pi/systemd/robot.env
-ExecStart=/usr/bin/python3 /workspaces/Rider-Pi/tools/newface_lcd_direct.py --expr neutral --rotate ${FACE_LCD_ROTATE:-0} --spi-hz ${FACE_LCD_SPI_HZ:-32000000} --stats
+ExecStart=/usr/bin/python3 /workspaces/Rider-Pi/tools/newface_lcd_direct.py --expr neutral --force ${FACE_LCD_FORCE:-auto} --driver ${FACE_LCD_DRIVER:-auto} --rotate ${FACE_LCD_ROTATE:-0} --spi-hz ${FACE_LCD_SPI_HZ:-32000000} --bl-pin ${FACE_LCD_BL_PIN:-13} --stats
 Restart=on-failure
 
 [Install]

--- a/tools/newface_lcd_direct.py
+++ b/tools/newface_lcd_direct.py
@@ -246,7 +246,6 @@ def main():
                 except Exception:
                     frame = fc.frame()
                     img = Image.open(BytesIO(frame)).convert("RGB")
-                # symulacja: po prostu konwersja do PNG
                 _ = to_png_bytes(img)
                 n += 1
                 if args.stats and (now - last_stats) >= 1.0:
@@ -264,36 +263,3 @@ def main():
             else:
                 print(f"[PIL] Brak wygenerowanych klatek.", flush=True)
         return
-    # RAW/LCD path:
-    lcd = LCDDirect(rotate=args.rotate, size=args.size, spi_hz=args.spi_hz, bl_pin=args.bl_pin, force=force)
-
-    n = 0; t0 = time.time(); last_stats = t0
-    try:
-        while True:
-            now = time.time()
-            if args.secs is not None and (now - t0) >= args.secs:
-                print("[LCD] Osiągnięto limit czasu --secs, kończę pętlę.", flush=True)
-                break
-            try:
-                img = fc.frame_image().convert("RGB")
-            except Exception:
-                frame = fc.frame()
-                img = Image.open(BytesIO(frame)).convert("RGB")
-            how = lcd.push(img)
-            n += 1
-            if args.stats and (now - last_stats) >= 1.0:
-                dt = now - t0
-                print(f"[stats] frames={n} fps~{(n/dt if dt>0 else 0):.1f} via {how}", flush=True)
-                last_stats = now
-            time.sleep(1.0 / max(1, args.fps))
-    except KeyboardInterrupt:
-        print("LCD loop finished.")
-    finally:
-        t1 = time.time()
-        dt = t1 - t0
-        if n > 0:
-            print(f"[LCD] Statystyki: klatek={n}, czas={dt:.2f}s, FPS={n/dt:.2f}", flush=True)
-        else:
-            print(f"[LCD] Brak wygenerowanych klatek.", flush=True)
-if __name__=="__main__":
-    main()


### PR DESCRIPTION
Zakres:
- Shim w services/api_core/face_api.py: używa FaceRenderer.render_png_bytes(face_state) → zapis PNG do pliku.
- Podpięcie /face/render do shima w services/api_server.py (503 dla LCD bez HW).
- Importy bez side-effectów; brak wymagań HW dla backend=png/sink=file.

Smoketest (Pi):
- POST /face/render {"expr":"neutral","backend":"png","out":"/tmp/face_api.png","rotate":270,"size":240} → 200 + plik OK
- POST /face/render {"expr":"neutral","backend":"lcd"} → 503 z komunikatem "LCD backend not available on this host"

Dalszy zakres (do dopięcia w tym issue/PR lub kolejnym kroku Phase-3):
- autodetekcja sterownika LCD i realny RAW path dla CLI/API (FPS ~18–20),
- docs: przykłady curl/ENV, troubleshooting LCD.

Closes #13 (jeśli RAW będzie domknięty w tym PR); w przeciwnym razie zostawiamy #13 otwarte i prosimy agenta o dokończenie RAW/LCD.
