### PR TITLE
Phase 4 — Face animation API (play/stop/state) + global CORS + /api/bus/health

### DIFF
--- a/services/api_core/face_anim.py
+++ b/services/api_core/face_anim.py
@@ -1,52 +1,101 @@
-# services/api_core/face_anim.py
-from time import time
-from flask import request, jsonify, make_response
+from __future__ import annotations
+from typing import Dict, Any
+from types import SimpleNamespace
+import threading, time
 
-# Prosty stan w pamięci (wystarczy na MVP)
-STATE = {
+# Renderer nowej buźki (snapshot do PNG w pętli; LCD dodamy później)
+from apps.ui.face.renderer import FaceRenderer
+
+ALLOWED = {"neutral", "happy", "sad", "blink"}
+
+def _norm_expr(v: str) -> str:
+    v = str(v or "neutral").strip().lower()
+    return v if v in ALLOWED else "neutral"
+
+# Globalny, prosty stan animacji utrzymywany w pamięci procesu
+STATE: Dict[str, Any] = {
     "playing": False,
+    "running": False,
     "expr": "neutral",
     "fps": 20,
-    "running": False,    # alias na potrzeby UI
     "started_ts": None,
     "last_ts": None,
 }
 
-ALLOWED = {"neutral", "happy", "sad", "blink"}
+# ──────────────────────────────────────────────────────────────────────────────
+# Animator: pętla w tle sterowana /face/play|/stop; na razie renderuje PNG bytes
+# (możesz opcjonalnie zapisywać do /tmp/face_runtime.png dla debugowania)
+# ──────────────────────────────────────────────────────────────────────────────
+class _Animator:
+    def __init__(self):
+        self._thr: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._renderer: FaceRenderer | None = None
 
-def _corsify(resp):
-    resp.headers["Access-Control-Allow-Origin"] = "*"
-    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
-    resp.headers["Access-Control-Allow-Methods"] = "GET,POST,OPTIONS"
-    return resp
+    def start(self):
+        if self._thr and self._thr.is_alive():
+            return
+        self._stop.clear()
+        self._thr = threading.Thread(target=self._loop, name="face-anim", daemon=True)
+        self._thr.start()
 
-def _norm_expr(v):
-    v = str(v or "neutral").lower().strip()
-    return v if v in ALLOWED else "neutral"
+    def stop(self):
+        self._stop.set()
 
-def post_play():
-    if request.method == "OPTIONS":
-        return _corsify(make_response("", 204))
-    p = request.get_json(silent=True) or {}
-    STATE["expr"] = _norm_expr(p.get("expr"))
-    try:
-        STATE["fps"] = int(p.get("fps", 20))
-    except Exception:
-        STATE["fps"] = 20
-    STATE["playing"] = True
-    STATE["running"] = True
-    STATE["started_ts"] = time()
-    STATE["last_ts"] = STATE["started_ts"]
-    return _corsify(jsonify({"ok": True, "state": STATE})), 200
+    def _loop(self):
+        try:
+            # docelowo: cfg z modelu; na razie pusty dict jest OK
+            self._renderer = FaceRenderer(cfg={}, size=240, guide=False, quality="fast")
+        except Exception:
+            self._renderer = None
 
-def post_stop():
-    if request.method == "OPTIONS":
-        return _corsify(make_response("", 204))
+        STATE["running"] = True
+        STATE["started_ts"] = time.time()
+        last = time.time()
+
+        while not self._stop.is_set() and STATE.get("playing", False):
+            fps = max(1, min(60, int(STATE.get("fps", 20) or 20)))
+            expr = _norm_expr(STATE.get("expr"))
+            # Minimalny FaceState „lookalike” – wystarcza do rysunku
+            face_state = SimpleNamespace(expr=expr, blink=False, pupil=0, tilt=0)
+
+            try:
+                if self._renderer:
+                    png = self._renderer.render_png_bytes(face_state)
+                    # DEBUG (opcjonalnie): podejrzenie ostatniej klatki
+                    # with open("/tmp/face_runtime.png", "wb") as f:
+                    #     f.write(png)
+            except Exception:
+                # pętla ma żyć dalej, nawet jeśli jedna klatka się wywali
+                pass
+
+            STATE["last_ts"] = time.time()
+            dt = 1.0 / fps
+            # zachowaj mniej więcej zadany FPS
+            time.sleep(max(0.0, dt - (STATE["last_ts"] - last)))
+            last = time.time()
+
+        STATE["running"] = False
+
+_anim = _Animator()
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Czyste funkcje biznesowe wywoływane z services/api_server.py
+# Zwracają czyste dicty; HTTP/JSON/CORS dodaje serwer.
+# ──────────────────────────────────────────────────────────────────────────────
+def play(payload: Dict[str, Any]) -> Dict[str, Any]:
+    expr = _norm_expr(payload.get("expr"))
+    fps = max(1, min(60, int(payload.get("fps", STATE.get("fps", 20) or 20))))
+    STATE.update({"expr": expr, "fps": fps, "playing": True})
+    _anim.start()
+    return {"ok": True, "state": STATE}
+
+def stop(_payload: Dict[str, Any] | None = None) -> Dict[str, Any]:
     STATE["playing"] = False
-    STATE["running"] = False
-    STATE["last_ts"] = time()
-    return _corsify(jsonify({"ok": True, "state": STATE})), 200
+    _anim.stop()
+    return {"ok": True, "state": STATE}
 
-def get_state():
-    # bez preflight – GET
-    return _corsify(jsonify({"ok": True, "state": STATE})), 200
+def get_state() -> Dict[str, Any]:
+    return {"ok": True, "state": STATE}
+
+

--- a/services/api_core/face_anim.py
+++ b/services/api_core/face_anim.py
@@ -1,0 +1,52 @@
+# services/api_core/face_anim.py
+from time import time
+from flask import request, jsonify, make_response
+
+# Prosty stan w pamięci (wystarczy na MVP)
+STATE = {
+    "playing": False,
+    "expr": "neutral",
+    "fps": 20,
+    "running": False,    # alias na potrzeby UI
+    "started_ts": None,
+    "last_ts": None,
+}
+
+ALLOWED = {"neutral", "happy", "sad", "blink"}
+
+def _corsify(resp):
+    resp.headers["Access-Control-Allow-Origin"] = "*"
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    resp.headers["Access-Control-Allow-Methods"] = "GET,POST,OPTIONS"
+    return resp
+
+def _norm_expr(v):
+    v = str(v or "neutral").lower().strip()
+    return v if v in ALLOWED else "neutral"
+
+def post_play():
+    if request.method == "OPTIONS":
+        return _corsify(make_response("", 204))
+    p = request.get_json(silent=True) or {}
+    STATE["expr"] = _norm_expr(p.get("expr"))
+    try:
+        STATE["fps"] = int(p.get("fps", 20))
+    except Exception:
+        STATE["fps"] = 20
+    STATE["playing"] = True
+    STATE["running"] = True
+    STATE["started_ts"] = time()
+    STATE["last_ts"] = STATE["started_ts"]
+    return _corsify(jsonify({"ok": True, "state": STATE})), 200
+
+def post_stop():
+    if request.method == "OPTIONS":
+        return _corsify(make_response("", 204))
+    STATE["playing"] = False
+    STATE["running"] = False
+    STATE["last_ts"] = time()
+    return _corsify(jsonify({"ok": True, "state": STATE})), 200
+
+def get_state():
+    # bez preflight – GET
+    return _corsify(jsonify({"ok": True, "state": STATE})), 200

--- a/services/api_core/face_anim.py
+++ b/services/api_core/face_anim.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 from typing import Dict, Any
 from types import SimpleNamespace
-import threading, time
+import threading
+import time
 
 # Renderer nowej buźki (snapshot do PNG w pętli; LCD dodamy później)
 from apps.ui.face.renderer import FaceRenderer
 
+# ── Konfiguracja/kontrakt plików wyjściowych ─────────────────────────────────
+OUT_LATEST = "/tmp/face_latest.png"         # nowy kontrakt (DoD)
+OUT_LEGACY = "/tmp/face_render_loop.png"    # zgodność wstecz
+
 ALLOWED = {"neutral", "happy", "sad", "blink"}
+
 
 def _norm_expr(v: str) -> str:
     v = str(v or "neutral").strip().lower()
     return v if v in ALLOWED else "neutral"
+
 
 # Globalny, prosty stan animacji utrzymywany w pamięci procesu
 STATE: Dict[str, Any] = {
@@ -20,11 +27,12 @@ STATE: Dict[str, Any] = {
     "fps": 20,
     "started_ts": None,
     "last_ts": None,
+    "frame_count": 0,
 }
 
+
 # ──────────────────────────────────────────────────────────────────────────────
-# Animator: pętla w tle sterowana /face/play|/stop; na razie renderuje PNG bytes
-# (możesz opcjonalnie zapisywać do /tmp/face_runtime.png dla debugowania)
+# Animator: pętla w tle sterowana /face/play|/stop; renderuje do PNG bytes
 # ──────────────────────────────────────────────────────────────────────────────
 class _Animator:
     def __init__(self):
@@ -33,6 +41,7 @@ class _Animator:
         self._renderer: FaceRenderer | None = None
 
     def start(self):
+        # uruchom tylko jeśli nie działa
         if self._thr and self._thr.is_alive():
             return
         self._stop.clear()
@@ -40,7 +49,13 @@ class _Animator:
         self._thr.start()
 
     def stop(self):
+        # sygnał zatrzymania — pętla sprawdza zarówno flagę, jak i STATE["playing"]
         self._stop.set()
+
+    def join(self, timeout: float | None = None):
+        t = self._thr
+        if t and t.is_alive():
+            t.join(timeout=timeout)
 
     def _loop(self):
         try:
@@ -50,10 +65,13 @@ class _Animator:
             self._renderer = None
 
         STATE["running"] = True
-        STATE["started_ts"] = time.time()
-        last = time.time()
+        # nie nadpisuj started_ts przy resume tego samego „play”
+        if not STATE.get("started_ts"):
+            STATE["started_ts"] = time.time()
 
-        while not self._stop.is_set() and STATE.get("playing", False):
+        last_tick = time.time()
+
+        while (not self._stop.is_set()) and STATE.get("playing", False):
             fps = max(1, min(60, int(STATE.get("fps", 20) or 20)))
             expr = _norm_expr(STATE.get("expr"))
             # Minimalny FaceState „lookalike” – wystarcza do rysunku
@@ -62,40 +80,95 @@ class _Animator:
             try:
                 if self._renderer:
                     png = self._renderer.render_png_bytes(face_state)
-                    # DEBUG (opcjonalnie): podejrzenie ostatniej klatki
-                    # with open("/tmp/face_runtime.png", "wb") as f:
-                    #     f.write(png)
+                    # Zapisz finalną klatkę (kontrakt DoD + zgodność)
+                    try:
+                        with open(OUT_LATEST, "wb") as f:
+                            f.write(png)
+                        try:
+                            with open(OUT_LEGACY, "wb") as f2:
+                                f2.write(png)
+                        except Exception:
+                            pass  # legacy opcjonalne
+                    except Exception:
+                        pass  # zapis nie może zabić pętli
             except Exception:
                 # pętla ma żyć dalej, nawet jeśli jedna klatka się wywali
                 pass
 
+            # Aktualizuj stan
             STATE["last_ts"] = time.time()
-            dt = 1.0 / fps
+            STATE["frame_count"] = int(STATE.get("frame_count") or 0) + 1
+
             # zachowaj mniej więcej zadany FPS
-            time.sleep(max(0.0, dt - (STATE["last_ts"] - last)))
-            last = time.time()
+            dt = 1.0 / fps
+            sleep_left = dt - (STATE["last_ts"] - last_tick)
+            if sleep_left > 0:
+                # krótsze spanie = szybsze reagowanie na stop()
+                time.sleep(min(sleep_left, 0.05))
+                # dociągnij resztę (jeśli była potrzeba)
+                remain = sleep_left - 0.05
+                if remain > 0:
+                    time.sleep(remain)
+            last_tick = time.time()
 
         STATE["running"] = False
 
+
 _anim = _Animator()
 
+
 # ──────────────────────────────────────────────────────────────────────────────
-# Czyste funkcje biznesowe wywoływane z services/api_server.py
-# Zwracają czyste dicty; HTTP/JSON/CORS dodaje serwer.
+# Czyste funkcje biznesowe (używane także przez „view” shimy)
 # ──────────────────────────────────────────────────────────────────────────────
 def play(payload: Dict[str, Any]) -> Dict[str, Any]:
     expr = _norm_expr(payload.get("expr"))
     fps = max(1, min(60, int(payload.get("fps", STATE.get("fps", 20) or 20))))
-    STATE.update({"expr": expr, "fps": fps, "playing": True})
+    STATE.update(
+        {
+            "expr": expr,
+            "fps": fps,
+            "playing": True,
+            "started_ts": time.time(),
+            "frame_count": 0,
+            "last_ts": None,
+        }
+    )
     _anim.start()
     return {"ok": True, "state": STATE}
+
 
 def stop(_payload: Dict[str, Any] | None = None) -> Dict[str, Any]:
     STATE["playing"] = False
     _anim.stop()
+    # daj pętli do 0.5 s na eleganckie zejście (DoD: stop < 0.5 s)
+    _anim.join(timeout=0.5)
+    if STATE.get("running") and (_anim._thr and _anim._thr.is_alive()):
+        # jeśli nie zdążył się wyłączyć, zostaw „running” zgodnie z realnym stanem
+        # (zwykle dojdzie do False za moment)
+        pass
     return {"ok": True, "state": STATE}
+
 
 def get_state() -> Dict[str, Any]:
     return {"ok": True, "state": STATE}
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Flask view shims: możesz bezpośrednio rejestrować je w app.add_url_rule(...)
+# (dzięki temu ten moduł pozostaje samowystarczalny)
+# ──────────────────────────────────────────────────────────────────────────────
+def post_play():
+    from flask import request, make_response, jsonify
+
+    if request.method == "OPTIONS":
+        return make_response("", 204)
+    payload = request.get_json(silent=True) or {}
+    return jsonify(play(payload))
+
+
+def post_stop():
+    from flask import request, make_response, jsonify
+
+    if request.method == "OPTIONS":
+        return make_response("", 204)
+    return jsonify(stop({}))

--- a/services/api_server.py
+++ b/services/api_server.py
@@ -8,7 +8,11 @@ from flask import Flask, jsonify, request, make_response, send_from_directory
 try:
     import services.api_core.compat as compat
     app: Flask = getattr(compat, "app", Flask(__name__))
-    DEFAULT_PORT = int(os.getenv("STATUS_API_PORT") or os.getenv("API_PORT") or getattr(compat, "STATUS_API_PORT", 5000))
+    DEFAULT_PORT = int(
+        os.getenv("STATUS_API_PORT")
+        or os.getenv("API_PORT")
+        or getattr(compat, "STATUS_API_PORT", 5000)
+    )
 except Exception:
     compat = None  # type: ignore
     app = Flask(__name__)
@@ -28,7 +32,6 @@ import services.api_core.chat_glue as chat_glue  # dla nowego glue
 # Face (nowa ścieżka + legacy shim)
 from services.api_core.face_api import render_face as face_render_shim
 import services.api_core.face_anim as face_anim
-
 
 # ── CORS global (dla dashboardu na 8080 i API na 5000) ───────────────────────
 @app.after_request
@@ -53,11 +56,27 @@ def face_render():
     status = 503 if (not res.get("ok") and res.get("status") == 503) else 200
     return jsonify(res), status
 
+# ── FACE: animacja (Phase 4 – HTTP shims do czystych funkcji) ───────────────
+@app.route("/face/play", methods=["POST", "OPTIONS"])
+def face_play():
+    if request.method == "OPTIONS":
+        return _corsify(make_response("", 204))
+    payload = request.get_json(silent=True) or {}
+    res = face_anim.play(payload)   # czysta funkcja -> dict
+    return _corsify(jsonify(res)), 200
 
-# Face animation (Phase 4 – MVP)
-app.add_url_rule("/face/play",  view_func=face_anim.post_play,  methods=["POST", "OPTIONS"])
-app.add_url_rule("/face/stop",  view_func=face_anim.post_stop,  methods=["POST", "OPTIONS"])
-app.add_url_rule("/face/state", view_func=face_anim.get_state,  methods=["GET"])
+@app.route("/face/stop", methods=["POST", "OPTIONS"])
+def face_stop():
+    if request.method == "OPTIONS":
+        return _corsify(make_response("", 204))
+    payload = request.get_json(silent=True) or {}
+    res = face_anim.stop(payload)   # czysta funkcja -> dict
+    return _corsify(jsonify(res)), 200
+
+@app.route("/face/state", methods=["GET"])
+def face_state():
+    res = face_anim.get_state()     # czysta funkcja -> dict
+    return _corsify(jsonify(res)), 200
 
 # ── FACE: legacy /api/draw/face (kompat) ─────────────────────────────────────
 @app.route("/api/draw/face", methods=["POST", "OPTIONS"])
@@ -122,6 +141,13 @@ _add_rule("/api/cmd", view_func=control_proxy.control_proxy_handler, methods=["P
 # voice proxy
 _add_rule("/api/voice/capture", view_func=voice_proxy.capture_handler, methods=["POST", "OPTIONS"])
 _add_rule("/api/voice/say", view_func=voice_proxy.say_handler, methods=["POST", "OPTIONS"])
+
+# bus health (stub) – żeby dashboard nie dostawał 404
+@app.route("/api/bus/health", methods=["GET", "OPTIONS"])
+def _bus_health():
+    if request.method == "OPTIONS":
+        return _corsify(make_response("", 204))
+    return _corsify(jsonify({"ok": True})), 200
 
 # ── Chat API: rejestracja „glue” idempotentnie ───────────────────────────────
 try:

--- a/services/api_server.py
+++ b/services/api_server.py
@@ -27,6 +27,8 @@ import services.api_core.chat_api as chat_api  # noqa: F401
 import services.api_core.chat_glue as chat_glue  # dla nowego glue
 # Face (nowa ścieżka + legacy shim)
 from services.api_core.face_api import render_face as face_render_shim
+import services.api_core.face_anim as face_anim
+
 
 # ── CORS global (dla dashboardu na 8080 i API na 5000) ───────────────────────
 @app.after_request
@@ -50,6 +52,12 @@ def face_render():
     res = face_render_shim(payload)
     status = 503 if (not res.get("ok") and res.get("status") == 503) else 200
     return jsonify(res), status
+
+
+# Face animation (Phase 4 – MVP)
+app.add_url_rule("/face/play",  view_func=face_anim.post_play,  methods=["POST", "OPTIONS"])
+app.add_url_rule("/face/stop",  view_func=face_anim.post_stop,  methods=["POST", "OPTIONS"])
+app.add_url_rule("/face/state", view_func=face_anim.get_state,  methods=["GET"])
 
 # ── FACE: legacy /api/draw/face (kompat) ─────────────────────────────────────
 @app.route("/api/draw/face", methods=["POST", "OPTIONS"])

--- a/tests/test_face_anim_api.py
+++ b/tests/test_face_anim_api.py
@@ -1,0 +1,165 @@
+# tests/test_face_anim_api.py
+import os
+import time
+import sys
+import pathlib
+
+import pytest
+
+# Import same Flask app as serwer – import NIE uruchamia main()
+from services.api_server import app
+from services.api_core import face_anim as fa
+
+
+@pytest.fixture(autouse=True)
+def _clean_anim():
+    """Zatrzymuj pętlę przed/po teście i porządkuj stan oraz pliki."""
+    # stop na wypadek "wiszącej" animacji
+    try:
+        fa.stop({})
+    except Exception:
+        pass
+
+    # reset stanu
+    fa.STATE.update(
+        {
+            "playing": False,
+            "running": False,
+            "expr": "neutral",
+            "fps": 20,
+            "started_ts": None,
+            "last_ts": None,
+            "frame_count": 0,
+        }
+    )
+
+    # usuń artefakty
+    for p in (fa.OUT_LATEST, fa.OUT_LEGACY, "/tmp/face_api_test.png", "/tmp/face_api_legacy_test.png"):
+        try:
+            os.remove(p)
+        except FileNotFoundError:
+            pass
+
+    yield
+
+    # ensure stop na końcu
+    try:
+        fa.stop({})
+    except Exception:
+        pass
+
+
+def _client():
+    return app.test_client()
+
+
+def _poll_until(fn, timeout=0.6, step=0.03):
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        if fn():
+            return True
+        time.sleep(step)
+    return False
+
+
+def test_play_state_stop_flow():
+    c = _client()
+
+    # start
+    rv = c.post("/face/play", json={"expr": "happy", "fps": 20})
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["ok"] is True
+    assert data["state"]["playing"] is True
+
+    time.sleep(0.25)
+
+    # sprawdź state
+    rv = c.get("/face/state")
+    assert rv.status_code == 200
+    st = rv.get_json()["state"]
+    assert st["playing"] is True
+    assert st["last_ts"] is not None
+    assert int(st["frame_count"]) >= 1
+
+    # stop
+    rv = c.post("/face/stop", json={})
+    assert rv.status_code == 200
+    assert rv.get_json()["ok"] is True
+
+    # DoD: stopuje się < ~0.5 s
+    ok = _poll_until(lambda: _client().get("/face/state").get_json()["state"]["playing"] is False, timeout=0.6)
+    assert ok, "playing nie przeszło na False w 0.6 s"
+
+
+def test_face_latest_png_written():
+    c = _client()
+
+    assert not os.path.exists(fa.OUT_LATEST)
+    rv = c.post("/face/play", json={"expr": "neutral", "fps": 15})
+    assert rv.status_code == 200
+
+    time.sleep(0.35)  # pozwól wyrenderować kilka klatek
+
+    assert os.path.exists(fa.OUT_LATEST), "brak /tmp/face_latest.png"
+    assert os.path.getsize(fa.OUT_LATEST) > 1000, "plik jest zbyt mały (<1 KB?)"
+
+    # stop
+    c.post("/face/stop", json={})
+
+
+def test_snapshot_png_backend_ok():
+    c = _client()
+    out = "/tmp/face_api_test.png"
+    try:
+        os.remove(out)
+    except FileNotFoundError:
+        pass
+
+    rv = c.post(
+        "/face/render",
+        json={"expr": "neutral", "backend": "png", "out": out, "rotate": 270, "size": 240},
+    )
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["ok"] is True
+    assert data["out"] == out
+    assert os.path.exists(out)
+    assert os.path.getsize(out) > 1000
+
+
+def test_legacy_draw_face_ok():
+    c = _client()
+    out = "/tmp/face_api_legacy_test.png"
+    try:
+        os.remove(out)
+    except FileNotFoundError:
+        pass
+
+    rv = c.post("/api/draw/face", json={"expr": "neutral", "backend": "png", "out": out})
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["ok"] is True
+    assert os.path.exists(out)
+    assert os.path.getsize(out) > 1000
+
+
+def test_global_cors_header_present():
+    c = _client()
+    rv = c.get("/face/ping")
+    # after_request w api_server powinien dodać nagłówki
+    assert rv.headers.get("Access-Control-Allow-Origin") == "*"
+    assert "GET" in rv.headers.get("Access-Control-Allow-Methods", "")
+
+
+def test_no_lcd_spi_imports():
+    # Best-effort: w trakcie animacji w sys.modules nie powinno być sterowników LCD/SPI
+    c = _client()
+    c.post("/face/play", json={"expr": "neutral", "fps": 15})
+    time.sleep(0.2)
+
+    forbidden = [k for k in sys.modules.keys() if k.startswith("apps.hw") or "sink_lcd" in k or "spi" in k]
+    # dozwolone: puste — nie chcemy HW w tej fazie
+    assert not forbidden, f"wygląda na importy HW: {forbidden[:5]}"
+
+    c.post("/face/stop", json={})


### PR DESCRIPTION
- Nowe endpointy (MVP animacji buźki):
  - POST /face/play — start animacji, JSON: {"expr":"happy|neutral|sad|blink", "fps": 15}
  - GET /face/state — odczyt stanu (playing, running, fps, expr, started_ts, last_ts)
  - POST /face/stop — zatrzymanie
- Snapshot: /face/render bez zmian (PNG do pliku).
- Globalny CORS (GET/POST/OPTIONS).
- Stub: GET /api/bus/health (zwraca 200, {ok:true}).
- Port kontraktowy 8080 utrzymany (zgodnie z ARCHITECTURE.md).
- Kompatybilność: legacy /api/draw/face nadal działa (zwrot PNG; LCD bez HW → 503).
- Technicznie
- Serwer: pełny routing (health/state/sysinfo/metrics/events/camera/svc/control/voice/chat glue).
- Face anim: prosty runtime w pamięci procesu; render PNG w pętli będzie w kolejnym PR (LCD sink także w kolejnych krokach fazy 4).
- Brak side-effectów importów (lazy), globalny CORS po after_request.