### PR TITLE
Fix voice UI state resets when hearing ends without speech

### DIFF
--- a/apps/voice/service.py
+++ b/apps/voice/service.py
@@ -8,7 +8,17 @@ import time
 import wave
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, TYPE_CHECKING
+
+try:  # pragma: no cover - optional dependency
+    from common.bus import BusPub as RuntimeBusPub
+except Exception:  # pragma: no cover - optional dependency
+    RuntimeBusPub = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from common.bus import BusPub as BusPubType
+else:  # pragma: no cover - runtime fallback
+    BusPubType = Any
 
 from . import logging as voice_logging
 from .asr import ASRConfig, Transcript, transcribe
@@ -69,6 +79,16 @@ class VoiceService:
         self._save_audio = bool(service_cfg.get("save_audio", False))
         self._recordings_dir = Path(service_cfg.get("recordings_dir", "data/recordings"))
 
+        publish_ui = bool(service_cfg.get("publish_ui_state", True))
+        self._ui_pub: BusPubType | None = None
+        self._last_ui_state: str | None = None
+        if publish_ui and RuntimeBusPub is not None:
+            try:
+                self._ui_pub = RuntimeBusPub()
+            except Exception as exc:  # pragma: no cover - optional dependency
+                self.logger.warning("service.ui_state.publisher_error", error=str(exc))
+                self._ui_pub = None
+
     # ─────────────────────────────────────────────
 
     def stop(self) -> None:
@@ -82,6 +102,7 @@ class VoiceService:
                     self._cycle()
                 except Exception as exc:
                     self.logger.error("service.cycle.error", error=str(exc))
+                    self._publish_ui_state("idle")
                     time.sleep(0.3)
         finally:
             self.logger.event("service.listen.stop")
@@ -104,56 +125,85 @@ class VoiceService:
         if self._should_ding():
             play_ding(self._play_cfg, self.logger)
 
+    def _publish_ui_state(self, state: str) -> None:
+        if not self._ui_pub:
+            return
+        if self._last_ui_state == state:
+            return
+        try:
+            self._ui_pub.publish("ui.state", {"state": state}, add_ts=True)
+            self._last_ui_state = state
+        except Exception as exc:  # pragma: no cover - bus optional
+            self.logger.debug("service.ui_state.publish_error", error=str(exc))
+
     # Główna logika cyklu
     def _cycle(self, *, speak: bool = True) -> VoiceResult:
+        delegated_to_speech = False
+        self._publish_ui_state("hearing")
+        try:
         # PTT: czekamy na ENTER bez otwartego mikrofonu → gramy ding → dopiero potem nagrywamy
-        if self._hotword_engine == "ptt" or (not self._hotword_enabled):
-            if not self._wait_hotword_without_capture():
-                raise RuntimeError("Hotword/PTT timeout")
-            if speak:
-                self._play_start_ding()
-            audio = self._record_with_vad()
-        else:
-            # klasyczny hotword: potrzebuje audio do detekcji
-            with AudioCapture(self._capture_cfg, self.logger) as capture:
-                if not self._hotword.wait(capture):
-                    raise RuntimeError("Hotword timeout")
+            if self._hotword_engine == "ptt" or (not self._hotword_enabled):
+                if not self._wait_hotword_without_capture():
+                    raise RuntimeError("Hotword/PTT timeout")
                 if speak:
                     self._play_start_ding()
-                # po ding zbieramy właściwe wypowiedzi
-                audio = collect(capture.frames(), self._vad, self._max_len)
+                audio = self._record_with_vad()
+            else:
+                # klasyczny hotword: potrzebuje audio do detekcji
+                with AudioCapture(self._capture_cfg, self.logger) as capture:
+                    if not self._hotword.wait(capture):
+                        raise RuntimeError("Hotword timeout")
+                    if speak:
+                        self._play_start_ding()
+                    # po ding zbieramy właściwe wypowiedzi
+                    audio = collect(capture.frames(), self._vad, self._max_len)
 
-        if not audio:
-            raise RuntimeError("No audio captured")
+            if not audio:
+                raise RuntimeError("No audio captured")
 
-        if self._save_audio:
-            self._save_pcm(audio)
+            if self._save_audio:
+                self._save_pcm(audio)
 
-        start = time.time()
-        transcript = transcribe(audio, self._capture_cfg.sample_rate, self._asr_cfg, self.logger)
-        # widoczność transkryptu
-        self.logger.event("service.asr.transcript", text=transcript.text)
+            self._publish_ui_state("thinking")
 
-        intent = self._nlu.route(transcript.text)
-        reply = self._handle_intent(intent)
+            start = time.time()
+            transcript = transcribe(audio, self._capture_cfg.sample_rate, self._asr_cfg, self.logger)
+            # widoczność transkryptu
+            self.logger.event("service.asr.transcript", text=transcript.text)
 
-        audio_out, sample_rate, fmt = synthesize(reply, self._tts_cfg, self.logger)
-        if speak:
-            # nieblokujące odtwarzanie
-            play_bytes(audio_out, fmt, self._play_cfg, self.logger, blocking=False)
+            intent = self._nlu.route(transcript.text)
+            reply = self._handle_intent(intent)
+            stripped_reply = reply.strip()
 
-        latency = time.time() - start
-        self.logger.event("service.cycle.done", latency=latency, intent=intent.kind)
+            audio_out: bytes | None = None
+            sample_rate = 0
+            fmt = ""
 
-        return VoiceResult(
-            transcript=transcript,
-            intent=intent,
-            reply=reply,
-            latency_s=latency,
-            audio=audio_out,
-            audio_format=fmt,
-            sample_rate=sample_rate,
-        )
+            if stripped_reply:
+                audio_out, sample_rate, fmt = synthesize(reply, self._tts_cfg, self.logger)
+                if speak and audio_out:
+                    self._publish_ui_state("speaking")
+                    # nieblokujące odtwarzanie
+                    play_bytes(audio_out, fmt, self._play_cfg, self.logger, blocking=False)
+                    delegated_to_speech = True
+            else:
+                self.logger.event("service.reply.empty")
+
+            latency = time.time() - start
+            self.logger.event("service.cycle.done", latency=latency, intent=intent.kind)
+
+            return VoiceResult(
+                transcript=transcript,
+                intent=intent,
+                reply=reply,
+                latency_s=latency,
+                audio=audio_out,
+                audio_format=fmt,
+                sample_rate=sample_rate,
+            )
+        finally:
+            if not delegated_to_speech:
+                self._publish_ui_state("idle")
 
     # ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- add an optional UI-state publisher to the voice service and emit hearing/thinking/speaking transitions
- ensure idle is published whenever a turn ends without handing audio to playback and guard listen-loop errors the same way
- keep the bus idle state consistent by logging empty replies instead of delegating to speech playback

## Testing
- manual script verifying bus state sequence returns to idle after empty reply and capture failure scenarios
- pytest *(fails: missing optional dependencies `services`, `requests`, `PIL`, `zmq` required by unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9f6f9528832f834f41e5b8e34023