### PR TITLE
Fix voice service UI state resets on silent turns

### DIFF
--- a/apps/voice/service.py
+++ b/apps/voice/service.py
@@ -10,6 +10,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
+try:  # pragma: no cover - optional dependency (pyzmq)
+    from common.bus import BusPub
+except Exception:  # pragma: no cover - running without bus support
+    BusPub = None  # type: ignore[assignment]
+
 from . import logging as voice_logging
 from .asr import ASRConfig, Transcript, transcribe
 from .capture import AudioCapture, CaptureConfig
@@ -33,7 +38,7 @@ class VoiceResult:
 
 
 class VoiceService:
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: dict[str, Any], *, ui_publisher: Any | None = None):
         self.config = config
         self.logger = voice_logging.get_logger("voice.service")
         self.stop_event = threading.Event()
@@ -68,6 +73,9 @@ class VoiceService:
         service_cfg = config.get("service", {})
         self._save_audio = bool(service_cfg.get("save_audio", False))
         self._recordings_dir = Path(service_cfg.get("recordings_dir", "data/recordings"))
+        self._ui_topic = str(service_cfg.get("ui_topic", "ui.state"))
+        self._ui_pub = ui_publisher or self._create_ui_publisher(service_cfg)
+        self._last_ui_state: str | None = None
 
     # ─────────────────────────────────────────────
 
@@ -76,14 +84,17 @@ class VoiceService:
 
     def listen(self) -> None:
         self.logger.event("service.listen.start")
+        self._publish_ui_state("idle")
         try:
             while not self.stop_event.is_set():
                 try:
                     self._cycle()
                 except Exception as exc:
+                    self._publish_ui_state("idle")
                     self.logger.error("service.cycle.error", error=str(exc))
                     time.sleep(0.3)
         finally:
+            self._publish_ui_state("idle")
             self.logger.event("service.listen.stop")
 
     def once(self, *, speak: bool = True) -> VoiceResult | None:
@@ -104,6 +115,40 @@ class VoiceService:
         if self._should_ding():
             play_ding(self._play_cfg, self.logger)
 
+    def _create_ui_publisher(self, service_cfg: dict[str, Any]) -> Any | None:
+        if BusPub is None:  # pragma: no cover - optional dependency missing
+            return None
+        try:
+            bus_cfg = service_cfg.get("ui_bus", {}) if isinstance(service_cfg, dict) else {}
+            prefix = str(bus_cfg.get("prefix", "") or "")
+            warmup = int(bus_cfg.get("warmup_ms", 0) or 0)
+            return BusPub(prefix, warmup)
+        except Exception as exc:  # pragma: no cover - optional bus
+            self.logger.warning("service.ui_state.publisher_failed", error=str(exc))
+            return None
+
+    def _publish_ui_state(self, state: str) -> None:
+        if self._last_ui_state == state:
+            return
+        if not self._ui_pub:
+            self._last_ui_state = state
+            return
+        payload = {"state": state, "ts": time.time()}
+        for attr in ("publish", "send", "pub"):
+            method = getattr(self._ui_pub, attr, None)
+            if callable(method):
+                try:
+                    method(self._ui_topic, payload)
+                except Exception as exc:
+                    self.logger.error(
+                        "service.ui_state.publish_failed", state=state, error=str(exc)
+                    )
+                else:
+                    self._last_ui_state = state
+                return
+        self.logger.warning("service.ui_state.unsupported_publisher")
+        self._last_ui_state = state
+
     # Główna logika cyklu
     def _cycle(self, *, speak: bool = True) -> VoiceResult:
         # PTT: czekamy na ENTER bez otwartego mikrofonu → gramy ding → dopiero potem nagrywamy
@@ -112,6 +157,7 @@ class VoiceService:
                 raise RuntimeError("Hotword/PTT timeout")
             if speak:
                 self._play_start_ding()
+            self._publish_ui_state("hearing")
             audio = self._record_with_vad()
         else:
             # klasyczny hotword: potrzebuje audio do detekcji
@@ -121,14 +167,17 @@ class VoiceService:
                 if speak:
                     self._play_start_ding()
                 # po ding zbieramy właściwe wypowiedzi
+                self._publish_ui_state("hearing")
                 audio = collect(capture.frames(), self._vad, self._max_len)
 
         if not audio:
+            self._publish_ui_state("idle")
             raise RuntimeError("No audio captured")
 
         if self._save_audio:
             self._save_pcm(audio)
 
+        self._publish_ui_state("thinking")
         start = time.time()
         transcript = transcribe(audio, self._capture_cfg.sample_rate, self._asr_cfg, self.logger)
         # widoczność transkryptu
@@ -136,11 +185,21 @@ class VoiceService:
 
         intent = self._nlu.route(transcript.text)
         reply = self._handle_intent(intent)
+        reply_text = reply.strip()
 
-        audio_out, sample_rate, fmt = synthesize(reply, self._tts_cfg, self.logger)
-        if speak:
-            # nieblokujące odtwarzanie
-            play_bytes(audio_out, fmt, self._play_cfg, self.logger, blocking=False)
+        audio_out: bytes | None = None
+        sample_rate = 0
+        fmt = ""
+        queued_tts = False
+        if reply_text:
+            audio_out, sample_rate, fmt = synthesize(reply_text, self._tts_cfg, self.logger)
+            if speak:
+                self._publish_ui_state("speaking")
+                queued_tts = True
+                # nieblokujące odtwarzanie
+                play_bytes(audio_out, fmt, self._play_cfg, self.logger, blocking=False)
+        if not queued_tts:
+            self._publish_ui_state("idle")
 
         latency = time.time() - start
         self.logger.event("service.cycle.done", latency=latency, intent=intent.kind)

--- a/tests/test_voice_service_ui_state.py
+++ b/tests/test_voice_service_ui_state.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import copy
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+class _RequestsStub:
+    RequestException = Exception
+
+    @staticmethod
+    def post(*_args, **_kwargs):  # pragma: no cover - placeholder
+        class _Resp:
+            status_code = 200
+            headers = {}
+            content = b""
+            text = ""
+
+            def json(self):  # pragma: no cover - compatibility
+                return {}
+
+        return _Resp()
+
+
+sys.modules.setdefault("requests", _RequestsStub())
+
+from apps.voice.asr import Transcript
+from apps.voice.service import VoiceService
+
+
+class FakePublisher:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, dict]] = []
+
+    def publish(self, topic: str, payload: dict, add_ts: bool = False) -> None:  # noqa: ARG002 - compatibility
+        self.messages.append((topic, dict(payload)))
+
+    def send(self, topic: str, payload: dict) -> None:  # pragma: no cover - legacy compatibility
+        self.publish(topic, payload)
+
+
+_BASE_CONFIG = {
+    "chat": {
+        "backend": "echo",
+        "model": "dummy",
+        "system_prompt": "",
+        "max_history": 1,
+    },
+    "nlu": {
+        "chat_threshold": 0.0,
+        "command_keywords": {},
+        "llm_model": "dummy",
+    },
+    "capture": {
+        "backend": "pulse",
+        "device": None,
+        "sample_rate": 16000,
+        "channels": 1,
+        "frame_ms": 20,
+        "buffer_seconds": 1,
+        "command": None,
+    },
+    "asr": {
+        "backend": "openai",
+        "model": "dummy",
+        "language": "en",
+    },
+    "tts": {
+        "backend": "openai",
+        "model": "dummy",
+        "voice": "dummy",
+        "format": "wav",
+    },
+    "playback": {
+        "backend": "pulse",
+        "alsa_device": None,
+        "volume": 100,
+        "ding": {"enabled": False},
+    },
+    "hotword": {
+        "enabled": False,
+        "engine": "off",
+        "model": None,
+        "sensitivity": 0.5,
+        "auto_gain": 1.0,
+        "threshold": 0.5,
+    },
+    "vad": {
+        "mode": 3,
+        "frame_ms": 30,
+        "tail_ms": 350,
+        "max_len_ms": 4500,
+        "energy_gate_dbfs": -36.0,
+    },
+    "service": {
+        "save_audio": False,
+        "recordings_dir": "data/recordings",
+    },
+    "logging": {
+        "level": "INFO",
+    },
+}
+
+
+def _base_config() -> dict:
+    return copy.deepcopy(_BASE_CONFIG)
+
+
+@pytest.fixture()
+def voice_module():
+    import apps.voice.service as voice_service_module
+
+    return voice_service_module
+
+
+def _state_sequence(publisher: FakePublisher) -> list[str]:
+    return [payload["state"] for topic, payload in publisher.messages if topic == "ui.state"]
+
+
+def test_cycle_emits_idle_when_reply_empty(monkeypatch: pytest.MonkeyPatch, voice_module) -> None:
+    config = _base_config()
+    publisher = FakePublisher()
+    service = VoiceService(config, ui_publisher=publisher)
+
+    monkeypatch.setattr(service, "_record_with_vad", lambda: b"\x00\x01" * 10)
+    monkeypatch.setattr(service, "_wait_hotword_without_capture", lambda: True)
+    monkeypatch.setattr(service, "_handle_intent", lambda intent: "   ")
+    monkeypatch.setattr(voice_module, "transcribe", lambda *args, **kwargs: Transcript(text="ok", language="en"))
+
+    synth_calls: list[str] = []
+
+    def fake_synthesize(text: str, *args, **kwargs):  # noqa: ANN001 - signature kept loose for patching
+        synth_calls.append(text)
+        return b"audio", 16000, "wav"
+
+    monkeypatch.setattr(voice_module, "synthesize", fake_synthesize)
+    monkeypatch.setattr(voice_module, "play_bytes", lambda *args, **kwargs: None)
+
+    result = service._cycle()
+
+    assert synth_calls == [], "TTS should not run when reply is empty"
+    states = _state_sequence(publisher)
+    assert states == ["hearing", "thinking", "idle"]
+    assert result.audio is None
+    assert result.audio_format == ""
+    assert result.sample_rate == 0
+
+
+def test_cycle_idle_after_short_recording(monkeypatch: pytest.MonkeyPatch, voice_module) -> None:
+    config = _base_config()
+    publisher = FakePublisher()
+    service = VoiceService(config, ui_publisher=publisher)
+
+    monkeypatch.setattr(service, "_record_with_vad", lambda: b"")
+    monkeypatch.setattr(service, "_wait_hotword_without_capture", lambda: True)
+
+    with pytest.raises(RuntimeError):
+        service._cycle()
+
+    states = _state_sequence(publisher)
+    assert states[-2:] == ["hearing", "idle"], states
+
+
+def test_listen_resets_state_after_cycle_error(monkeypatch: pytest.MonkeyPatch, voice_module) -> None:
+    config = _base_config()
+    publisher = FakePublisher()
+    service = VoiceService(config, ui_publisher=publisher)
+
+    class OneShotEvent:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def is_set(self) -> bool:
+            self.calls += 1
+            return self.calls >= 2
+
+        def set(self) -> None:  # pragma: no cover - compatibility with threading.Event
+            self.calls = 2
+
+    service.stop_event = OneShotEvent()
+
+    def failing_cycle(*args, **kwargs):  # noqa: ANN001 - match _cycle signature
+        service._publish_ui_state("hearing")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(service, "_cycle", failing_cycle)
+    monkeypatch.setattr(voice_module.time, "sleep", lambda *_args, **_kwargs: None)
+
+    service.listen()
+
+    states = _state_sequence(publisher)
+    assert states[-2:] == ["hearing", "idle"], states


### PR DESCRIPTION
## Summary
- ensure `VoiceService` emits `ui.state` transitions, including resetting to `idle` when no TTS is queued or errors occur
- guard the optional bus dependency and publish distinct `hearing`/`thinking`/`speaking` states during a turn
- add regression tests covering idle transitions for silent replies, short recordings, and cycle failures

## Testing
- pytest tests/test_voice_service_ui_state.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9ab3b98c832f96e81527e41efe0c