### PR TITLE
Fix streaming voice default PTT detection

### DIFF
--- a/apps/voice/svc_stream.py
+++ b/apps/voice/svc_stream.py
@@ -210,11 +210,35 @@ class StreamingVoiceService(StreamingVoiceTransportMixin, StreamingVoicePTTMixin
         self._completed: bool = False
 
         # --- PTT (push-to-talk) sterowanie Enterem ---
-        hotword_cfg = self.config.get("hotword") or {}
+        hotword_cfg = dict(self.config.get("hotword") or {})
         ptt_cfg = self.config.get("ptt") or {}
-        self.ptt_enabled: bool = str(hotword_cfg.get("engine", "")).lower() == "ptt" or bool(
-            ptt_cfg.get("enabled", False)
+        service_cfg = self.config.get("service") or {}
+        turn_cfg = service_cfg.get("turn") or self.config.get("turn") or {}
+
+        service_hotword_engine = str(service_cfg.get("hotword_engine", "")).strip().lower()
+        service_hotword_enabled = service_cfg.get("hotword_enabled")
+        commit_on_key = bool(turn_cfg.get("commit_on_key", False))
+
+        hotword_engine = str(hotword_cfg.get("engine", "")).strip().lower()
+        if not hotword_engine:
+            if service_hotword_engine:
+                hotword_engine = service_hotword_engine
+            elif service_hotword_enabled is False:
+                hotword_engine = ""
+            else:
+                # Kompatybilność: domyślnie traktuj brak konfiguracji jako PTT
+                hotword_engine = "ptt"
+
+        self.ptt_enabled: bool = (
+            hotword_engine == "ptt"
+            or bool(ptt_cfg.get("enabled", False))
+            or commit_on_key
         )
+        if service_hotword_enabled is False:
+            self.ptt_enabled = False
+
+        # zachowaj wyliczony engine (dla debugowania/ew. przyszłego użycia)
+        self._ptt_engine = hotword_engine
         self.ptt_active: bool = False  # czy aktualnie nagrywamy po Enter
         self._ptt_was_active: bool = False  # detekcja zbocza STOP (True->False)
         self._any_audio_since_commit: bool = False  # czy coś poleciało od startu PTT

--- a/tests/test_voice_stream_ptt_defaults.py
+++ b/tests/test_voice_stream_ptt_defaults.py
@@ -1,0 +1,58 @@
+"""Tests for default PTT behaviour in streaming voice service."""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+from apps.voice.svc_stream import StreamingVoiceService
+
+
+@pytest.fixture
+def base_config() -> dict[str, object]:
+    """Return minimal streaming configuration without explicit hotword section."""
+
+    return {
+        "stream": {"endpoint": "ws://test", "auth": "dummy"},
+        "capture": {"sample_rate": 16000, "channels": 1},
+        "playback": {},
+        "service": {"turn": {"commit_on_key": True}},
+    }
+
+
+def _cleanup(service: StreamingVoiceService) -> None:
+    """Ensure threads/events are stopped after each test."""
+
+    with contextlib.suppress(Exception):
+        service.stop()
+
+
+def test_ptt_enabled_by_default(base_config):
+    """PTT should auto-enable when configuration omits explicit hotword settings."""
+
+    service = StreamingVoiceService(base_config)
+    try:
+        assert service.ptt_enabled is True
+        assert service.ptt_controller.ptt_enabled is True
+        assert service.audio_transmitter.ptt_enabled is True
+    finally:
+        _cleanup(service)
+
+
+def test_ptt_disabled_when_service_hotword_disabled(base_config):
+    """Explicitly disabling hotword should turn off PTT even with commit_on_key."""
+
+    cfg = dict(base_config)
+    cfg_service = dict(cfg.get("service", {}))
+    cfg_service.update({"hotword_enabled": False})
+    cfg["service"] = cfg_service
+
+    service = StreamingVoiceService(cfg)
+    try:
+        assert service.ptt_enabled is False
+        assert service.ptt_controller.ptt_enabled is False
+        assert service.audio_transmitter.ptt_enabled is False
+    finally:
+        _cleanup(service)
+


### PR DESCRIPTION
## Summary
- ensure the streaming voice service enables push-to-talk by default when no explicit hotword engine is configured
- respect service hotword disable flags and cover the behaviour with regression tests

## Testing
- PYTHONPATH=. pytest tests/test_voice_stream_ptt_defaults.py -q
- ruff check apps/voice/svc_stream.py tests/test_voice_stream_ptt_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68e4a868bda4832fabeba110aa08157e